### PR TITLE
fix: improves error handling for failed downloads #1

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ Command-line interface and main entry point
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, NoReturn
 
 import click
 
@@ -14,6 +14,25 @@ from sc2am.logger import setup_logging
 from sc2am.validator import URLValidator
 from sc2am.downloader import Downloader
 from sc2am.apple_music import AppleMusicManager
+
+
+def _exit_with_error(logger, message: str) -> NoReturn:
+    click.secho(f"ERROR: {message}", fg='red')
+    logger.error(message)
+    sys.exit(1)
+
+
+def _create_downloader(cfg, logger) -> Downloader:
+    try:
+        return Downloader(cfg.download_dir)
+    except RuntimeError as exc:
+        _exit_with_error(logger, str(exc))
+
+
+def _require_downloaded_file(file_path: Optional[Path], logger) -> Path:
+    if file_path is None:
+        _exit_with_error(logger, "Download completed but no file was found.")
+    return file_path
 
 
 @click.group()
@@ -90,22 +109,20 @@ def download(ctx, url: str, playlist: Optional[str], no_open: bool):
     # Validate URL
     is_valid, platform = URLValidator.validate_url(url)
     if not is_valid:
-        click.secho(f"ERROR: Invalid URL: {platform}", fg='red')
-        logger.error(f"Invalid URL: {platform}")
-        sys.exit(1)
+        _exit_with_error(logger, f"Invalid URL: {platform}")
 
     click.secho(f"OK: Valid {platform} URL", fg='green')
     logger.debug(f"URL validated as {platform}")
 
     # Download track
     click.echo("Downloading track...")
-    downloader = Downloader(cfg.download_dir)
+    downloader = _create_downloader(cfg, logger)
     success, file_path, message = downloader.download(url)
 
     if not success:
-        click.secho(f"ERROR: Download failed: {message}", fg='red')
-        logger.error(f"Download failed: {message}")
-        sys.exit(1)
+        _exit_with_error(logger, message)
+
+    file_path = _require_downloaded_file(file_path, logger)
 
     click.secho(f"OK: {message}", fg='green')
     logger.info(f"Successfully downloaded to {file_path}")
@@ -169,15 +186,14 @@ def batch(ctx, batch_file: str, playlist: Optional[str], continue_on_error: bool
             logger.error(f"Line {line_num}: {error}")
 
     if not urls:
-        click.secho("No valid URLs found in batch file.", fg='yellow')
-        logger.warning("No valid URLs in batch file")
-        sys.exit(1)
+        _exit_with_error(logger, "No valid URLs found in batch file.")
 
     click.secho(f"OK: Found {len(urls)} valid URL(s)", fg='green')
     logger.info(f"Found {len(urls)} valid URLs")
 
     # Process each URL
-    downloader = Downloader(cfg.download_dir)
+    downloader = _create_downloader(cfg, logger)
+
     music_manager = AppleMusicManager()
     successful = 0
     failed = 0
@@ -189,12 +205,14 @@ def batch(ctx, batch_file: str, playlist: Optional[str], continue_on_error: bool
         # Download
         success, file_path, message = downloader.download(url)
         if not success:
-            click.secho(f"  ERROR: Download failed: {message}", fg='red')
-            logger.error(f"Download failed: {message}")
+            click.secho(f"  ERROR: {message}", fg='red')
+            logger.error(message)
             failed += 1
             if not continue_on_error:
                 sys.exit(1)
             continue
+
+        file_path = _require_downloaded_file(file_path, logger)
 
         click.secho("  OK: Downloaded", fg='green')
         successful += 1

--- a/sc2am/downloader.py
+++ b/sc2am/downloader.py
@@ -4,8 +4,8 @@ Handles downloading audio from various platforms using yt-dlp.
 """
 
 import logging
-import subprocess
 import json
+import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple
 import shutil
@@ -17,7 +17,42 @@ logger = logging.getLogger(__name__)
 
 class Downloader:
     """Downloads audio tracks from supported platforms."""
-    
+
+    _INVALID_URL_PATTERNS = (
+        "unsupported url",
+        "invalid url",
+        "no suitable extractors",
+        "no extractors found",
+        "not a valid url",
+    )
+    _TEMPORARY_NETWORK_PATTERNS = (
+        "timed out",
+        "timeout",
+        "temporary failure",
+        "name or service not known",
+        "connection refused",
+        "connection reset",
+        "network is unreachable",
+        "unable to download webpage",
+        "http error 5",
+        "bad gateway",
+        "gateway timeout",
+        "service unavailable",
+    )
+    _ACCESS_PATTERNS = (
+        "http error 401",
+        "http error 403",
+        "forbidden",
+        "access denied",
+        "private",
+    )
+    _NOT_FOUND_PATTERNS = (
+        "http error 404",
+        "not found",
+        "deleted",
+        "removed",
+    )
+
     def __init__(self, download_dir: Path):
         """
         Initialize downloader.
@@ -32,12 +67,12 @@ class Downloader:
     @staticmethod
     def _check_dependencies() -> None:
         """Check if yt-dlp is installed."""
-        result = shutil.which('yt-dlp')
-        if not result:
+        yt_dlp_path = shutil.which('yt-dlp')
+        if not yt_dlp_path:
             raise RuntimeError(
                 "yt-dlp is not installed. Install it with: pip install yt-dlp"
             )
-        logger.debug("yt-dlp found at: " + result)
+        logger.debug(f"yt-dlp found at: {yt_dlp_path}")
 
     def download(self, url: str) -> Tuple[bool, Optional[Path], str]:
         """
@@ -84,10 +119,10 @@ class Downloader:
             )
             
             if result.returncode != 0:
-                error_msg = result.stderr or "Unknown error"
+                error_msg = self._classify_download_error(result.stderr)
                 logger.error(f"Download failed: {error_msg}")
-                return False, None, f"Download failed: {error_msg}"
-            
+                return False, None, error_msg
+
             downloaded_file = self._resolve_downloaded_file(result.stdout)
             if downloaded_file is None:
                 return False, None, "No MP3 file found after download"
@@ -105,11 +140,36 @@ class Downloader:
             return True, downloaded_file, f"Downloaded: {downloaded_file.name}{metadata_message}"
         
         except subprocess.TimeoutExpired:
-            logger.error("Download timeout")
-            return False, None, "Download timeout (exceeded 5 minutes)"
+            message = "Download timed out after 5 minutes. Please try again later."
+            logger.error(message)
+            return False, None, message
         except Exception as e:
-            logger.error(f"Unexpected error during download: {e}")
-            return False, None, f"Unexpected error: {str(e)}"
+            message = f"Unexpected download error: {str(e)}"
+            logger.error(message)
+            return False, None, message
+
+    @classmethod
+    def _classify_download_error(cls, stderr: str) -> str:
+        """Convert yt-dlp failures into user-friendly messages."""
+        error_text = (stderr or "").strip()
+        lowered = error_text.lower()
+
+        if not error_text:
+            return "Download failed: yt-dlp returned an unknown error"
+
+        if any(pattern in lowered for pattern in cls._INVALID_URL_PATTERNS):
+            return f"Invalid or unsupported URL: {error_text}"
+
+        if any(pattern in lowered for pattern in cls._ACCESS_PATTERNS):
+            return f"Access denied or private track: {error_text}"
+
+        if any(pattern in lowered for pattern in cls._NOT_FOUND_PATTERNS):
+            return f"Track not found or removed: {error_text}"
+
+        if any(pattern in lowered for pattern in cls._TEMPORARY_NETWORK_PATTERNS):
+            return f"Temporary network error: {error_text}"
+
+        return f"Download failed: {error_text}"
 
     def _resolve_downloaded_file(self, stdout: str) -> Optional[Path]:
         """Resolve the resulting MP3 path from yt-dlp output with a fallback scan."""
@@ -151,9 +211,9 @@ class Downloader:
             )
             
             if result.returncode != 0:
-                error_msg = result.stderr or "Could not fetch track info"
-                return False, None, error_msg
-            
+                error_msg = Downloader._classify_download_error(result.stderr)
+                return False, None, f"Could not fetch track info: {error_msg}"
+
             info = json.loads(result.stdout)
             return True, info, "Info fetched successfully"
         

--- a/sc2am/validator.py
+++ b/sc2am/validator.py
@@ -52,7 +52,22 @@ class URLValidator:
                 return False, "URL is missing scheme or domain"
             
             # Extract domain without www
-            domain = parsed.netloc.replace('www.', '')
+            domain = (parsed.hostname or parsed.netloc).replace('www.', '')
+
+            if domain == 'soundcloud.com':
+                path_segments = [segment for segment in parsed.path.split('/') if segment]
+                if len(path_segments) != 2:
+                    return False, (
+                        "Unsupported SoundCloud URL. Please provide a track URL like "
+                        "https://soundcloud.com/<artist>/<track>"
+                    )
+
+                normalized_path = "/" + "/".join(path_segments)
+                if not URLValidator.SOUNDCLOUD_PATTERN.match(f"https://soundcloud.com{normalized_path}/"):
+                    return False, (
+                        "Unsupported SoundCloud URL. Please provide a track URL like "
+                        "https://soundcloud.com/<artist>/<track>"
+                    )
             
             for supported_domain, platform in URLValidator.SUPPORTED_DOMAINS.items():
                 if domain.endswith(supported_domain):


### PR DESCRIPTION
## Summary
This PR improves download error handling in `sc2am` so the CLI behaves more gracefully when downloads fail.

## What changed
- Added clearer error classification for yt-dlp failures
- Improved handling for temporary network issues, invalid URLs, private tracks, and missing tracks
- Added better CLI error messages and stable exit behavior
- Tightened SoundCloud URL validation so invalid track URLs are rejected earlier

## Why
The previous implementation returned generic or unclear errors in some failure cases. This change makes failures easier to understand and helps users recover faster.

## Testing
- Syntax checked successfully
- Validated URL parsing behavior
- Tested download error classification logic

## Notes
This PR keeps the CLI exit behavior consistent and does not change the core download workflow for successful imports.

Closes #1 