### PR TITLE
refactor: refactors configuration defaults #4

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from typing import Optional, NoReturn
 
 import click
 
-from sc2am.config_manager import ConfigManager
+from sc2am.config_manager import ConfigManager, LOG_LEVELS
 from sc2am.logger import setup_logging
 from sc2am.validator import URLValidator
 from sc2am.downloader import Downloader
@@ -46,8 +46,8 @@ def _require_downloaded_file(file_path: Optional[Path], logger) -> Path:
 )
 @click.option(
     '--log-level',
-    type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR']),
-    default='INFO',
+    type=click.Choice(LOG_LEVELS),
+    default=ConfigManager.default_config_data()["log_level"],
     help='Logging level'
 )
 @click.pass_context

--- a/sc2am/config_manager.py
+++ b/sc2am/config_manager.py
@@ -11,6 +11,12 @@ import yaml
 from pydantic import BaseModel, Field, field_validator, ConfigDict
 
 logger = logging.getLogger(__name__)
+LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def default_download_dir() -> Path:
+    """Return the default download directory for fresh installs."""
+    return Path.home() / "Downloads" / "sc2am"
 
 
 class AppConfig(BaseModel):
@@ -20,7 +26,7 @@ class AppConfig(BaseModel):
     
     # Paths
     download_dir: Path = Field(
-        default=Path.home() / "Downloads" / "sc2am",
+        default_factory=default_download_dir,
         description="Directory where MP3s will be downloaded"
     )
     
@@ -68,9 +74,8 @@ class AppConfig(BaseModel):
     @classmethod
     def validate_log_level(cls, v):
         """Ensure log level is valid."""
-        valid_levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
-        if v.upper() not in valid_levels:
-            raise ValueError(f"Log level must be one of {valid_levels}")
+        if v.upper() not in LOG_LEVELS:
+            raise ValueError(f"Log level must be one of {list(LOG_LEVELS)}")
         return v.upper()
 
 
@@ -79,7 +84,22 @@ class ConfigManager:
     
     CONFIG_DIR = Path.home() / ".sc2am"
     CONFIG_FILE = CONFIG_DIR / "config.yaml"
-    
+
+    @staticmethod
+    def _serialize_config_value(value: Any) -> Any:
+        if isinstance(value, Path):
+            return str(value)
+        return value
+
+    @staticmethod
+    def default_config_data() -> Dict[str, Any]:
+        """Build the canonical default configuration as plain YAML-safe data."""
+        default_config = AppConfig().model_dump(mode="python")
+        return {
+            key: ConfigManager._serialize_config_value(value)
+            for key, value in default_config.items()
+        }
+
     @staticmethod
     def get_config(config_path: Optional[Path] = None) -> AppConfig:
         """
@@ -162,19 +182,14 @@ class ConfigManager:
             logger.info(f"Config file already exists at {ConfigManager.CONFIG_FILE}")
             return ConfigManager.CONFIG_FILE
         
-        default_config = {
-            'download_dir': str(Path.home() / "Downloads" / "sc2am"),
-            'music_library_path': None,
-            'default_playlist': None,
-            'keep_downloads': True,
-            'open_music_app': True,
-            'log_level': 'INFO',
-            'log_file': None,
-        }
-        
         with open(ConfigManager.CONFIG_FILE, 'w') as f:
-            yaml.dump(default_config, f, default_flow_style=False)
-        
+            yaml.safe_dump(
+                ConfigManager.default_config_data(),
+                f,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+
         logger.info(f"Created default config at {ConfigManager.CONFIG_FILE}")
         return ConfigManager.CONFIG_FILE
 

--- a/sc2am/logger.py
+++ b/sc2am/logger.py
@@ -13,7 +13,7 @@ def setup_logging(log_level: str = "INFO", log_file: Optional[Path] = None) -> l
     Set up logging with both console and optional file handlers.
     
     Args:
-        log_level: Logging level (DEBUG, INFO, WARNING, ERROR)
+        log_level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
         log_file: Optional path to log file
         
     Returns:

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,0 +1,80 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+import sc2am.config_manager as config_manager
+from sc2am.config_manager import ConfigManager
+
+
+class ConfigDefaultTests(unittest.TestCase):
+    def test_default_config_data_uses_shared_model_defaults(self):
+        with tempfile.TemporaryDirectory() as temp_home:
+            home = Path(temp_home)
+            with patch.object(config_manager.Path, "home", return_value=home):
+                default_config = ConfigManager.default_config_data()
+
+        expected_download_dir = str(home / "Downloads" / "sc2am")
+        self.assertEqual(default_config["download_dir"], expected_download_dir)
+        self.assertIsNone(default_config["music_library_path"])
+        self.assertIsNone(default_config["default_playlist"])
+        self.assertTrue(default_config["keep_downloads"])
+        self.assertTrue(default_config["open_music_app"])
+        self.assertEqual(default_config["log_level"], "INFO")
+        self.assertIsNone(default_config["log_file"])
+
+    def test_create_default_config_writes_normalized_yaml(self):
+        with tempfile.TemporaryDirectory() as temp_home, tempfile.TemporaryDirectory() as temp_config:
+            home = Path(temp_home)
+            config_dir = Path(temp_config) / ".sc2am"
+            config_file = config_dir / "config.yaml"
+
+            with patch.object(config_manager.Path, "home", return_value=home), patch.object(
+                ConfigManager,
+                "CONFIG_DIR",
+                config_dir,
+            ), patch.object(
+                ConfigManager,
+                "CONFIG_FILE",
+                config_file,
+            ):
+                created_path = ConfigManager.create_default_config(force=True)
+
+            self.assertEqual(created_path, config_file)
+            self.assertTrue(config_file.exists())
+
+            written_config = yaml.safe_load(config_file.read_text())
+            expected_config = {
+                "download_dir": str(home / "Downloads" / "sc2am"),
+                "music_library_path": None,
+                "default_playlist": None,
+                "keep_downloads": True,
+                "open_music_app": True,
+                "log_level": "INFO",
+                "log_file": None,
+            }
+            self.assertEqual(written_config, expected_config)
+
+    def test_partial_config_load_still_fills_missing_defaults(self):
+        with tempfile.TemporaryDirectory() as temp_home, tempfile.TemporaryDirectory() as temp_config:
+            home = Path(temp_home)
+            config_file = Path(temp_config) / "config.yaml"
+            config_file.write_text(
+                "default_playlist: Roadtrip\nkeep_downloads: false\n"
+            )
+
+            with patch.object(config_manager.Path, "home", return_value=home):
+                cfg = ConfigManager.get_config(config_file)
+
+        self.assertEqual(cfg.download_dir, home / "Downloads" / "sc2am")
+        self.assertEqual(cfg.default_playlist, "Roadtrip")
+        self.assertFalse(cfg.keep_downloads)
+        self.assertTrue(cfg.open_music_app)
+        self.assertEqual(cfg.log_level, "INFO")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
Normalize configuration defaults so fresh installs and existing configs behave consistently.

## Changes
- Centralized default configuration values in `sc2am/config_manager.py`
- Made `config init` use the same default source as runtime loading
- Synchronized CLI log-level choices with the shared config defaults
- Added tests for default generation and partial config loading

## Testing
- python -m unittest tests.test_config_defaults tests.test_error_messages
- python -m unittest discover -s tests

Closes #4 