### PR TITLE
feat: adds basic tests for validator and config loading #5

### DIFF
--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -74,6 +74,55 @@ class ConfigDefaultTests(unittest.TestCase):
         self.assertTrue(cfg.open_music_app)
         self.assertEqual(cfg.log_level, "INFO")
 
+    def test_missing_config_file_still_returns_default_configuration(self):
+        with tempfile.TemporaryDirectory() as temp_home, tempfile.TemporaryDirectory() as temp_config:
+            home = Path(temp_home)
+            config_file = Path(temp_config) / "config.yaml"
+
+            with patch.object(config_manager.Path, "home", return_value=home):
+                cfg = ConfigManager.get_config(config_file)
+
+        self.assertEqual(cfg.download_dir, home / "Downloads" / "sc2am")
+        self.assertIsNone(cfg.music_library_path)
+        self.assertIsNone(cfg.default_playlist)
+        self.assertTrue(cfg.keep_downloads)
+        self.assertTrue(cfg.open_music_app)
+        self.assertEqual(cfg.log_level, "INFO")
+        self.assertIsNone(cfg.log_file)
+
+    def test_environment_variables_override_yaml_configuration(self):
+        with tempfile.TemporaryDirectory() as temp_home, tempfile.TemporaryDirectory() as temp_config:
+            home = Path(temp_home)
+            config_file = Path(temp_config) / "config.yaml"
+            config_file.write_text(
+                "download_dir: /tmp/from-yaml\n"
+                "default_playlist: YAML Playlist\n"
+                "keep_downloads: true\n"
+                "open_music_app: true\n"
+                "log_level: warning\n"
+            )
+
+            with patch.object(config_manager.Path, "home", return_value=home), patch.dict(
+                config_manager.os.environ,
+                {
+                    "SC2AM_DOWNLOAD_DIR": "/tmp/from-env",
+                    "SC2AM_PLAYLIST": "Env Playlist",
+                    "SC2AM_KEEP_DOWNLOADS": "false",
+                    "SC2AM_OPEN_MUSIC": "false",
+                    "SC2AM_LOG_LEVEL": "debug",
+                    "SC2AM_LOG_FILE": "/tmp/sc2am.log",
+                },
+                clear=False,
+            ):
+                cfg = ConfigManager.get_config(config_file)
+
+        self.assertEqual(cfg.download_dir, Path("/tmp/from-env"))
+        self.assertEqual(cfg.default_playlist, "Env Playlist")
+        self.assertFalse(cfg.keep_downloads)
+        self.assertFalse(cfg.open_music_app)
+        self.assertEqual(cfg.log_level, "DEBUG")
+        self.assertEqual(cfg.log_file, Path("/tmp/sc2am.log"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,36 @@
+import unittest
+
+from sc2am.validator import URLValidator
+
+
+class URLValidatorTests(unittest.TestCase):
+    def test_accepts_soundcloud_track_without_explicit_scheme(self):
+        is_valid, message = URLValidator.validate_url("soundcloud.com/artist/track")
+
+        self.assertTrue(is_valid)
+        self.assertEqual(message, "SoundCloud")
+
+    def test_rejects_soundcloud_urls_with_invalid_path_depth(self):
+        is_valid, message = URLValidator.validate_url("https://soundcloud.com/artist/track/remix")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(
+            message,
+            URLValidator.SOUNDCLOUD_TRACK_HELP,
+        )
+
+    def test_rejects_urls_without_domain(self):
+        is_valid, message = URLValidator.validate_url("https://")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(message, "The URL is missing a domain name.")
+
+    def test_rejects_non_string_values(self):
+        is_valid, message = URLValidator.validate_url(None)
+
+        self.assertFalse(is_valid)
+        self.assertEqual(message, "Please provide a valid URL.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add a small test coverage base for URL validation and configuration loading.

## What changed
- Added dedicated validator tests
- Extended config loading tests
- Covered:
  - missing config files
  - environment variable overrides
  - stricter SoundCloud URL validation

## Validation
- python -m unittest discover -s tests -p 'test_*.py'

Closes #5 