### PR TITLE
feat(metadata): improves title and artist metadata mapping #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python CLI tool that automates downloading tracks from SoundCloud and importing them into Apple Music on macOS.
 
-The downloaded MP3 files are automatically enriched with SoundCloud metadata (title, artist, album, genre, date) and cover artwork, so Apple Music shows the correct track information after import.
+The downloaded MP3 files are automatically enriched with SoundCloud metadata (title, artist, album, genre, date) and cover artwork, with improved title and artist mapping so Apple Music shows the correct track information after import.
 
 ## Installation
 

--- a/sc2am/metadata.py
+++ b/sc2am/metadata.py
@@ -5,6 +5,7 @@ Metadata embedding utilities for downloaded audio files.
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
@@ -106,13 +107,21 @@ class MetadataWriter:
         id3.save(str(file_path), v2_version=3)
 
     def _extract_tags(self, track_info: Dict[str, Any]) -> Dict[str, str]:
-        title = self._first_available(track_info.get("track"), track_info.get("title"), "Unknown Title")
+        track_value = track_info.get("track")
+        title = self._first_available(
+            self._first_available(track_value) if not self._looks_like_track_number(track_value) else "",
+            track_info.get("title"),
+            "Unknown Title",
+        )
         artist = self._first_available(
             track_info.get("artist"),
-            track_info.get("uploader"),
             track_info.get("creator"),
+            track_info.get("uploader"),
+            track_info.get("channel_name"),
+            track_info.get("channel"),
             "Unknown Artist",
         )
+        title = self._strip_artist_prefix(title, artist)
         album = self._first_available(track_info.get("album"), "SoundCloud")
         album_artist = self._first_available(track_info.get("album_artist"), artist)
         genre = self._first_available(track_info.get("genre"), "")
@@ -165,6 +174,39 @@ class MetadataWriter:
             if string_value:
                 return string_value
         return ""
+
+    @staticmethod
+    def _looks_like_track_number(value: Any) -> bool:
+        if isinstance(value, int):
+            return True
+        if isinstance(value, str):
+            stripped = value.strip()
+            return bool(stripped) and stripped.isdigit()
+        return False
+
+    @staticmethod
+    def _strip_artist_prefix(title: str, artist: str) -> str:
+        cleaned_title = title.strip()
+        cleaned_artist = artist.strip()
+
+        if not cleaned_title or not cleaned_artist:
+            return cleaned_title
+
+        separators = (" - ", " – ", " — ", " | ", ": ")
+        normalized_title = cleaned_title.lower()
+        normalized_artist = cleaned_artist.lower()
+
+        if normalized_title == normalized_artist:
+            return cleaned_title
+
+        for separator in separators:
+            prefix = f"{cleaned_artist}{separator}"
+            if normalized_title.startswith(prefix.lower()):
+                stripped_title = cleaned_title[len(prefix):].strip()
+                if stripped_title:
+                    return stripped_title
+
+        return re.sub(r"\s+", " ", cleaned_title)
 
     @staticmethod
     def _stringify(value: Any) -> str:

--- a/tests/test_metadata_mapping.py
+++ b/tests/test_metadata_mapping.py
@@ -1,0 +1,55 @@
+import unittest
+
+from sc2am.metadata import MetadataWriter
+
+
+class MetadataMappingTests(unittest.TestCase):
+    def setUp(self):
+        self.writer = MetadataWriter()
+
+    def test_extract_tags_strips_artist_prefix_from_title(self):
+        tags = self.writer._extract_tags(
+            {
+                "track": "Synthwave Collective - Night Drive",
+                "artist": "Synthwave Collective",
+                "album": "Midnight Sessions",
+            }
+        )
+
+        self.assertEqual(tags["title"], "Night Drive")
+        self.assertEqual(tags["artist"], "Synthwave Collective")
+        self.assertEqual(tags["albumartist"], "Synthwave Collective")
+        self.assertEqual(tags["album"], "Midnight Sessions")
+
+    def test_extract_tags_uses_title_when_track_is_numeric_and_creator_for_artist(self):
+        tags = self.writer._extract_tags(
+            {
+                "track": 4,
+                "title": "Morning Light",
+                "creator": "DJ Echo",
+            }
+        )
+
+        self.assertEqual(tags["title"], "Morning Light")
+        self.assertEqual(tags["artist"], "DJ Echo")
+        self.assertEqual(tags["albumartist"], "DJ Echo")
+
+    def test_extract_tags_falls_back_to_uploader_and_unknown_defaults(self):
+        tags = self.writer._extract_tags(
+            {
+                "title": "Lo-Fi Study Session",
+                "uploader": "Chill Beats Radio",
+            }
+        )
+
+        self.assertEqual(tags["title"], "Lo-Fi Study Session")
+        self.assertEqual(tags["artist"], "Chill Beats Radio")
+        self.assertEqual(tags["albumartist"], "Chill Beats Radio")
+        self.assertEqual(tags["genre"], "")
+        self.assertEqual(tags["date"], "")
+        self.assertEqual(tags["tracknumber"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
Improve how SoundCloud metadata is mapped into Apple Music tags, especially title and artist fields.

## Changes
- Prefer meaningful track metadata for title extraction
- Improve artist fallback order
- Strip duplicated artist prefixes from titles
- Keep album artist aligned with the primary artist
- Add tests for metadata mapping behavior

## Validation
- Ran the full unit test suite
- 19 tests passed

Closes #6 