### PR TITLE
fix(metadata): verifies imported artwork before Apple Music import #10

### DIFF
--- a/sc2am/metadata.py
+++ b/sc2am/metadata.py
@@ -37,8 +37,10 @@ class MetadataWriter:
         try:
             normalized_track_info = self._normalize_track_info(track_info)
             self._write_text_tags(file_path, normalized_track_info)
-            self._write_cover_art(file_path, normalized_track_info)
-            return True, "Metadata embedded"
+            artwork_verified = self._write_cover_art(file_path, normalized_track_info)
+            if artwork_verified:
+                return True, "Metadata embedded and artwork verified"
+            return True, "Metadata embedded, but artwork could not be verified"
         except Exception as exc:
             logger.error(f"Failed to embed metadata: {exc}")
             return False, str(exc)
@@ -136,15 +138,20 @@ class MetadataWriter:
             id3.add(TXXX(encoding=3, desc="SOURCE_URL", text=[source_url]))
         id3.save(str(file_path), v2_version=3)
 
-    def _write_cover_art(self, file_path: Path, track_info: Dict[str, Any]) -> None:
+    def _write_cover_art(self, file_path: Path, track_info: Dict[str, Any]) -> bool:
         for thumbnail_url in self._cover_art_candidates(track_info):
             image_bytes, mime = self._download_image(thumbnail_url)
+            if image_bytes and self._save_cover_art(file_path, image_bytes, mime):
+                return True
             if image_bytes:
-                self._save_cover_art(file_path, image_bytes, mime)
-                return
+                logger.warning("Artwork candidate downloaded successfully, but could not be verified after saving.")
 
         fallback_bytes, fallback_mime = self._fallback_cover_art()
-        self._save_cover_art(file_path, fallback_bytes, fallback_mime)
+        if self._save_cover_art(file_path, fallback_bytes, fallback_mime):
+            return True
+
+        logger.warning("Fallback artwork could not be verified after saving.")
+        return False
 
     def _extract_tags(self, track_info: Dict[str, Any]) -> Dict[str, str]:
         track_value = track_info.get("track")
@@ -533,9 +540,9 @@ class MetadataWriter:
             return "image/webp"
         return None
 
-    def _save_cover_art(self, file_path: Path, image_bytes: bytes, mime: str) -> None:
+    def _save_cover_art(self, file_path: Path, image_bytes: bytes, mime: str) -> bool:
         if not image_bytes:
-            return
+            return False
 
         try:
             id3 = ID3(str(file_path))
@@ -553,6 +560,23 @@ class MetadataWriter:
             )
         )
         id3.save(str(file_path), v2_version=3)
+        return self._verify_cover_art(file_path, image_bytes, mime)
+
+    @staticmethod
+    def _verify_cover_art(file_path: Path, image_bytes: bytes, mime: str) -> bool:
+        if not image_bytes:
+            return False
+
+        try:
+            id3 = ID3(str(file_path))
+        except ID3NoHeaderError:
+            return False
+
+        for apic in id3.getall("APIC"):
+            if apic.data == image_bytes and apic.mime == mime:
+                return True
+
+        return False
 
     @classmethod
     def _fallback_cover_art(cls) -> Tuple[bytes, str]:

--- a/tests/test_metadata_mapping.py
+++ b/tests/test_metadata_mapping.py
@@ -220,6 +220,56 @@ class MetadataMappingTests(unittest.TestCase):
             self.assertEqual(saved_args[1], b"large-image-bytes")
             self.assertEqual(saved_args[2], "image/jpeg")
 
+    def test_save_cover_art_verifies_the_written_artwork_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "track.mp3"
+            file_path.touch()
+            ID3().save(str(file_path), v2_version=3)
+
+            image_bytes = MetadataWriter.FALLBACK_COVER_ART_PNG
+            success = self.writer._save_cover_art(file_path, image_bytes, "image/png")
+
+            self.assertTrue(success)
+
+            id3 = ID3(str(file_path))
+            apic = id3.getall("APIC")[0]
+            self.assertEqual(apic.data, image_bytes)
+            self.assertEqual(apic.mime, "image/png")
+
+    def test_write_cover_art_retries_when_saved_artwork_cannot_be_verified(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "track.mp3"
+            file_path.touch()
+            ID3().save(str(file_path), v2_version=3)
+
+            track_info = {
+                "thumbnail": "https://example.com/broken.jpg",
+                "thumbnails": [
+                    {"url": "https://example.com/large.jpg", "width": 1280, "height": 720},
+                ],
+            }
+
+            with mock.patch.object(
+                self.writer,
+                "_download_image",
+                side_effect=[(b"broken-image-bytes", "image/jpeg"), (b"large-image-bytes", "image/jpeg")],
+            ):
+                with mock.patch.object(
+                    MetadataWriter,
+                    "_verify_cover_art",
+                    side_effect=[False, True],
+                ) as verify_mock:
+                    with mock.patch.object(
+                        MetadataWriter,
+                        "_fallback_cover_art",
+                        return_value=(b"fallback-cover", "image/png"),
+                    ) as fallback_mock:
+                        verified = self.writer._write_cover_art(file_path, track_info)
+
+            self.assertTrue(verified)
+            self.assertEqual(verify_mock.call_count, 2)
+            fallback_mock.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Verify embedded artwork during the tagging process so imported tracks are more likely to display the correct cover art in Apple Music.

## Changes
- Verify cover art after writing it into the MP3
- Retry with the next artwork candidate if verification fails
- Verify fallback artwork as well
- Add tests for roundtrip artwork verification and retry behavior

## Validation
- Ran the full test suite
- 28 tests passed

Closes #10 
