### PR TITLE
feat: adds final import summary #13

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,13 @@ def _resolve_playlist_name(cfg, playlist: Optional[str]) -> Optional[str]:
     return None
 
 
+def _print_run_summary(logger, succeeded: int, failed: int) -> None:
+    summary = f"Summary: {succeeded} succeeded, {failed} failed"
+    fg = 'green' if failed == 0 else 'yellow'
+    click.secho(summary, fg=fg, bold=True)
+    logger.info(summary)
+
+
 @click.group()
 @click.option(
     '--config',
@@ -147,58 +154,66 @@ def download(ctx: click.Context, url: str, playlist: Optional[str], no_open: boo
     cfg = state['config']
     logger = state['logger']
     track_label = _track_label()
+    succeeded = 0
+    failed = 0
 
-    logger.info(f"Processing URL: {url}")
+    try:
+        logger.info(f"Processing URL: {url}")
 
-    # Validate URL
-    _track_status(logger, track_label, "Validating SoundCloud URL...")
-    is_valid, platform = URLValidator.validate_url(url)
-    if not is_valid:
-        _exit_with_error(logger, platform)
+        # Validate URL
+        _track_status(logger, track_label, "Validating SoundCloud URL...")
+        is_valid, platform = URLValidator.validate_url(url)
+        if not is_valid:
+            failed = 1
+            _exit_with_error(logger, platform)
 
-    _track_status(logger, track_label, f"OK: Valid {platform} URL", fg='green')
-    logger.debug(f"URL validated as {platform}")
+        _track_status(logger, track_label, f"OK: Valid {platform} URL", fg='green')
+        logger.debug(f"URL validated as {platform}")
 
-    # Download track
-    _track_status(logger, track_label, "Downloading track...")
-    downloader = _create_downloader(cfg, logger)
-    success, file_path, message = downloader.download(url)
+        # Download track
+        _track_status(logger, track_label, "Downloading track...")
+        downloader = _create_downloader(cfg, logger)
+        success, file_path, message = downloader.download(url)
 
-    if not success:
-        _exit_with_error(logger, message)
+        if not success:
+            failed = 1
+            _exit_with_error(logger, message)
 
-    file_path = _require_downloaded_file(file_path, logger)
+        file_path = _require_downloaded_file(file_path, logger)
 
-    _track_status(logger, track_label, f"OK: {message}", fg='green')
-    logger.info(f"Successfully downloaded to {file_path}")
+        _track_status(logger, track_label, f"OK: {message}", fg='green')
+        logger.info(f"Successfully downloaded to {file_path}")
 
-    # Open with Apple Music
-    if not no_open and cfg.open_music_app:
-        _track_status(logger, track_label, "Opening with Apple Music...")
-        music_manager = AppleMusicManager()
-        success, msg = music_manager.open_file_with_music(file_path)
-        if success:
-            _track_status(logger, track_label, f"OK: {msg}", fg='green')
-            logger.info(msg)
-        else:
-            _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow')
-            logger.warning(msg)
+        # Open with Apple Music
+        if not no_open and cfg.open_music_app:
+            _track_status(logger, track_label, "Opening with Apple Music...")
+            music_manager = AppleMusicManager()
+            success, msg = music_manager.open_file_with_music(file_path)
+            if success:
+                _track_status(logger, track_label, f"OK: {msg}", fg='green')
+                logger.info(msg)
+            else:
+                _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow')
+                logger.warning(msg)
 
-    playlist_name = _resolve_playlist_name(cfg, playlist)
+        playlist_name = _resolve_playlist_name(cfg, playlist)
 
-    # Add to playlist
-    if playlist_name:
-        _track_status(logger, track_label, f"Adding to playlist '{playlist_name}'...")
-        music_manager = AppleMusicManager()
-        success, msg = music_manager.add_to_playlist(file_path, playlist_name)
-        if success:
-            _track_status(logger, track_label, f"OK: {msg}", fg='green')
-            logger.info(msg)
-        else:
-            _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow')
-            logger.warning(msg)
+        # Add to playlist
+        if playlist_name:
+            _track_status(logger, track_label, f"Adding to playlist '{playlist_name}'...")
+            music_manager = AppleMusicManager()
+            success, msg = music_manager.add_to_playlist(file_path, playlist_name)
+            if success:
+                _track_status(logger, track_label, f"OK: {msg}", fg='green')
+                logger.info(msg)
+            else:
+                _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow')
+                logger.warning(msg)
 
-    click.secho(f"\n{track_label}: Done!", fg='green', bold=True)
+        succeeded = 1
+        click.secho(f"\n{track_label}: Done!", fg='green', bold=True)
+    finally:
+        _print_run_summary(logger, succeeded, failed)
 
 
 @cli.command()
@@ -245,53 +260,56 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
     music_manager = AppleMusicManager()
     successful = 0
     failed = 0
+    abort_with_error = False
 
-    for i, url in enumerate(urls, 1):
-        track_label = _track_label(i, len(urls))
-        click.echo(f"\n{track_label}: Processing {url}")
-        logger.debug(f"Processing URL {i}/{len(urls)}")
+    try:
+        for i, url in enumerate(urls, 1):
+            track_label = _track_label(i, len(urls))
+            click.echo(f"\n{track_label}: Processing {url}")
+            logger.debug(f"Processing URL {i}/{len(urls)}")
 
-        # Download
-        _track_status(logger, track_label, "Downloading track...")
-        success, file_path, message = downloader.download(url)
-        if not success:
-            _track_status(logger, track_label, f"ERROR: {message}", fg='red', level='error')
-            failed += 1
-            if not continue_on_error:
-                sys.exit(1)
-            continue
+            # Download
+            _track_status(logger, track_label, "Downloading track...")
+            success, file_path, message = downloader.download(url)
+            if not success:
+                _track_status(logger, track_label, f"ERROR: {message}", fg='red', level='error')
+                failed += 1
+                if not continue_on_error:
+                    abort_with_error = True
+                    break
+                continue
 
-        file_path = _require_downloaded_file(file_path, logger)
+            file_path = _require_downloaded_file(file_path, logger)
 
-        _track_status(logger, track_label, "OK: Downloaded", fg='green')
-        successful += 1
+            _track_status(logger, track_label, "OK: Downloaded", fg='green')
+            successful += 1
 
-        # Open with Apple Music
-        if cfg.open_music_app:
-            _track_status(logger, track_label, "Opening with Apple Music...")
-            success, msg = music_manager.open_file_with_music(file_path)
-            if success:
-                _track_status(logger, track_label, "OK: Opened with Apple Music", fg='green')
-            else:
-                _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow', level='warning')
+            # Open with Apple Music
+            if cfg.open_music_app:
+                _track_status(logger, track_label, "Opening with Apple Music...")
+                success, msg = music_manager.open_file_with_music(file_path)
+                if success:
+                    _track_status(logger, track_label, "OK: Opened with Apple Music", fg='green')
+                else:
+                    _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow', level='warning')
 
-                playlist_name = _resolve_playlist_name(cfg, playlist)
+            playlist_name = _resolve_playlist_name(cfg, playlist)
 
-                # Add to playlist
-                if playlist_name:
-                    _track_status(logger, track_label, f"Adding to playlist '{playlist_name}'...")
-                    success, msg = music_manager.add_to_playlist(file_path, playlist_name)
-            if success:
-                _track_status(logger, track_label, "OK: Added to playlist", fg='green')
-            else:
-                _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow', level='warning')
+            # Add to playlist
+            if playlist_name:
+                _track_status(logger, track_label, f"Adding to playlist '{playlist_name}'...")
+                success, msg = music_manager.add_to_playlist(file_path, playlist_name)
+                if success:
+                    _track_status(logger, track_label, "OK: Added to playlist", fg='green')
+                else:
+                    _track_status(logger, track_label, f"WARNING: {msg}", fg='yellow', level='warning')
 
-        click.secho(f"{track_label}: Done!", fg='green', bold=True)
+            click.secho(f"{track_label}: Done!", fg='green', bold=True)
+    finally:
+        _print_run_summary(logger, successful, failed)
 
-    # Summary
-    click.echo("\n" + "=" * 50)
-    click.secho(f"Processed: {successful} successful, {failed} failed", fg='green', bold=True)
-    logger.info(f"Batch complete: {successful} successful, {failed} failed")
+    if abort_with_error:
+        sys.exit(1)
 
 
 @cli.group()

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,6 +1,7 @@
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import Mock
 from unittest import mock
 
@@ -145,6 +146,68 @@ class ErrorMessageTests(unittest.TestCase):
         log_args = logger.log.call_args.args
         self.assertEqual(log_args[0], main.logging.ERROR)
         self.assertEqual(log_args[1], "Track 1/1: ERROR: Failed")
+
+    def test_run_summary_reports_success_and_failure_counts(self):
+        logger = Mock()
+
+        with mock.patch.object(main.click, "secho") as secho_mock:
+            main._print_run_summary(logger, 3, 1)
+
+        secho_mock.assert_called_once_with("Summary: 3 succeeded, 1 failed", fg="yellow", bold=True)
+        logger.info.assert_called_once_with("Summary: 3 succeeded, 1 failed")
+
+    def test_download_shows_final_summary_for_successful_run(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+            file_path = download_dir / "track.mp3"
+            file_path.touch()
+
+            cfg = Mock(download_dir=download_dir, open_music_app=False, default_playlist=None)
+            logger = Mock()
+            ctx = mock.Mock()
+            ctx.obj = {"config": cfg, "logger": logger}
+
+            downloader = Mock()
+            downloader.download.return_value = (True, file_path, "Downloaded: track.mp3")
+
+            download_cmd = cast(Any, main.download)
+            with mock.patch.object(main.URLValidator, "validate_url", return_value=(True, "SoundCloud")), \
+                mock.patch.object(main, "_create_downloader", return_value=downloader), \
+                mock.patch.object(main.click, "secho") as secho_mock:
+                download_cmd.callback.__wrapped__(ctx, "https://soundcloud.com/artist/track", None, True)
+
+        secho_mock.assert_any_call("Summary: 1 succeeded, 0 failed", fg="green", bold=True)
+
+    def test_batch_shows_final_summary_with_success_and_failure_counts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch_file = Path(tmpdir) / "urls.txt"
+            batch_file.write_text("https://soundcloud.com/artist/one\nhttps://soundcloud.com/artist/two\n")
+
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+            file_path = download_dir / "track.mp3"
+            file_path.touch()
+
+            cfg = Mock(download_dir=download_dir, open_music_app=False, default_playlist=None)
+            logger = Mock()
+            ctx = mock.Mock()
+            ctx.obj = {"config": cfg, "logger": logger}
+
+            downloader = Mock()
+            downloader.download.side_effect = [
+                (True, file_path, "Downloaded: track.mp3"),
+                (False, None, "The URL is invalid or not supported. Please check the link and try again."),
+            ]
+
+            batch_cmd = cast(Any, main.batch)
+            with mock.patch.object(main.URLValidator, "validate_batch_file", return_value=(True, ["https://soundcloud.com/artist/one", "https://soundcloud.com/artist/two"], [])), \
+                mock.patch.object(main, "_create_downloader", return_value=downloader), \
+                mock.patch.object(main, "AppleMusicManager"), \
+                mock.patch.object(main.click, "secho") as secho_mock:
+                batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, True)
+
+        secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed", fg="yellow", bold=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add a concise end-of-run summary that reports success and failure counts for imports.

## Changes
- Show final success/failure counts after single downloads
- Show final success/failure counts after batch imports
- Keep summary output color-coded by result
- Add tests for summary output behavior

## Validation
- Ran the full test suite
- 36 tests passed

Closes #13 