### PR TITLE
docs: document macOS permissions ans prerequisites #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ The downloaded MP3 files are automatically enriched with SoundCloud metadata (ti
 - **Python 3.8+**
 - **yt-dlp** (will be installed as dependency)
 
+### macOS Prerequisites
+
+Apple Music automation relies on macOS permissions and Music.app being available locally. Before using SC2AM, make sure:
+
+- **Music.app is installed** and can be opened manually on this Mac.
+- **Music.app has been launched at least once** so the library is initialized.
+- **Automation permission is allowed** for the app you run SC2AM from, such as Terminal, iTerm, VS Code, or PyCharm.
+- **System Settings > Privacy & Security > Automation** allows that app to control Music.
+- **The Music library is accessible** on the current macOS account you are using.
+
+For a step-by-step checklist, see [`docs/macos-setup.md`](docs/macos-setup.md).
+
 ### Setup
 
 1. **Clone or download the project:**
@@ -116,15 +128,15 @@ python main.py download "https://soundcloud.com/artist/track"
 
 **Configuration Options:**
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `download_dir` | Path | `~/Downloads/sc2am` | Where to download MP3 files |
-| `music_library_path` | Path | auto-detect | Path to Music.app library |
-| `default_playlist` | String | none | Default playlist for imports |
-| `keep_downloads` | Bool | `true` | Keep MP3 files after import |
-| `open_music_app` | Bool | `true` | Auto-open Music.app |
-| `log_level` | String | `INFO` | Logging level |
-| `log_file` | Path | none | Optional log file path |
+| Option               | Type   | Default             | Description                  |
+|----------------------|--------|---------------------|------------------------------|
+| `download_dir`       | Path   | `~/Downloads/sc2am` | Where to download MP3 files  |
+| `music_library_path` | Path   | auto-detect         | Path to Music.app library    |
+| `default_playlist`   | String | none                | Default playlist for imports |
+| `keep_downloads`     | Bool   | `true`              | Keep MP3 files after import  |
+| `open_music_app`     | Bool   | `true`              | Auto-open Music.app          |
+| `log_level`          | String | `INFO`              | Logging level                |
+| `log_file`           | Path   | none                | Optional log file path       |
 
 ### Global Options
 
@@ -166,6 +178,13 @@ pip install yt-dlp --upgrade
 ### Apple Music not opening
 - Ensure Music.app is installed (comes with macOS)
 - Check your `open_music_app` setting in config
+- Confirm the app you use to run SC2AM has Automation permission for Music in System Settings
+
+### macOS permissions or prerequisites are missing
+- Open Music.app once manually and confirm it launches without errors
+- Go to **System Settings > Privacy & Security > Automation** and allow the app you use to run SC2AM to control Music
+- If you previously denied access, re-run SC2AM after re-enabling the permission so macOS can prompt again if needed
+- See [`docs/macos-setup.md`](docs/macos-setup.md) for the full checklist
 
 ### Adding to playlists fails
 - Playlist name must exactly match your Music.app playlists

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,21 +13,25 @@ SC2AM is a small command-line application that downloads a SoundCloud track, enr
 
 ## Module Responsibilities
 
-| Module | Responsibility |
-| --- | --- |
-| `main.py` | CLI commands, argument handling, and user-facing status output |
-| `sc2am/validator.py` | Strict URL validation and batch-file validation |
-| `sc2am/downloader.py` | Download orchestration, error classification, and metadata hand-off |
-| `sc2am/metadata.py` | Metadata normalization, tag writing, artwork extraction, and fallback handling |
-| `sc2am/apple_music.py` | macOS Music.app automation and playlist operations |
-| `sc2am/config_manager.py` | Configuration defaults, loading, and persistence |
-| `sc2am/logger.py` | Logging setup |
+| Module                    | Responsibility                                                                 |
+|---------------------------|--------------------------------------------------------------------------------|
+| `main.py`                 | CLI commands, argument handling, and user-facing status output                 |
+| `sc2am/validator.py`      | Strict URL validation and batch-file validation                                |
+| `sc2am/downloader.py`     | Download orchestration, error classification, and metadata hand-off            |
+| `sc2am/metadata.py`       | Metadata normalization, tag writing, artwork extraction, and fallback handling |
+| `sc2am/apple_music.py`    | macOS Music.app automation and playlist operations                             |
+| `sc2am/config_manager.py` | Configuration defaults, loading, and persistence                               |
+| `sc2am/logger.py`         | Logging setup                                                                  |
 
 ## Important Design Rules
 - Metadata should be normalized before tagging so downstream code receives predictable values.
 - Artwork handling should always prefer a valid embedded image and fall back safely when no usable artwork exists.
 - CLI errors should be clear enough for users to act on without reading stack traces.
 - The project should remain macOS-friendly but avoid hard-coding local paths or machine-specific assumptions.
+
+## macOS Setup Notes
+
+Apple Music automation depends on local macOS permissions and a working Music.app installation. The user-facing setup checklist lives in [`docs/macos-setup.md`](macos-setup.md), and the README links there as well.
 
 ## Testing Focus
 The most important tests cover:

--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -1,0 +1,66 @@
+# macOS Setup for Apple Music Automation
+
+SC2AM can only automate Apple Music reliably on macOS when a few local prerequisites are in place. This guide documents the checks you should do before importing tracks.
+
+## Required prerequisites
+
+- **macOS is installed and up to date enough to run Music.app automation**
+- **Music.app is installed** and can be opened manually
+- **Music.app has been launched at least once** so the library is initialized
+- **The current macOS user account has access to the Music library**
+- **The app you use to run SC2AM** has permission to control Music through macOS Automation
+
+## Grant Automation permission
+
+When SC2AM opens Music.app or adds a track to a playlist, macOS may require Automation permission for the app that launched SC2AM, such as Terminal, iTerm, Visual Studio Code, or PyCharm.
+
+1. Run SC2AM once so macOS can register the automation request.
+2. Open **System Settings**.
+3. Go to **Privacy & Security**.
+4. Open **Automation**.
+5. Allow the app you used to launch SC2AM to control **Music**.
+
+If you previously denied the permission, enabling it again here is usually enough. In some cases, you may need to quit and relaunch the terminal or editor app before retrying.
+
+## Verify Music.app manually
+
+Before running SC2AM, confirm that Music.app works on its own:
+
+1. Open **Music** manually.
+2. Confirm that the app opens without permission dialogs or library errors.
+3. Make sure your playlists are visible in the library.
+4. If you use iCloud Music Library or Sync Library, confirm it is signed in and available.
+
+## Common reliability checks
+
+- Use the same macOS user account for SC2AM and for Music.app.
+- Avoid running the tool from a temporary shell that cannot retain Automation prompts.
+- If playlist operations fail, verify the playlist name matches exactly as shown in Music.app.
+- If the app was moved, renamed, or reinstalled, re-check Automation permissions.
+
+## Troubleshooting
+
+### Music.app does not open
+
+- Confirm Music.app is installed and not restricted by Screen Time or device management policies.
+- Try opening Music.app manually before running SC2AM again.
+- Check whether `open_music_app` is enabled in your SC2AM configuration.
+
+### Automation prompts do not appear
+
+- Check **System Settings > Privacy & Security > Automation**.
+- Quit and reopen the app that launches SC2AM.
+- If necessary, remove and re-add the permission by toggling the Music entry off and on again.
+
+### Playlist import fails
+
+- Verify the playlist exists in Music.app.
+- Ensure the playlist name is spelled exactly the same, including spaces and punctuation.
+- If you have multiple playlists with the same name, rename one of them to make the selection unambiguous.
+
+## Related documentation
+
+- [`README.md`](../README.md)
+- [`docs/commands.md`](commands.md)
+- [`docs/architecture.md`](architecture.md)
+


### PR DESCRIPTION
# Summary

Document the macOS permissions and prerequisites required for Apple Music automation to work reliably. This adds a dedicated setup guide and links it from the main README and architecture docs.

## Changes
- Add `docs/macos-setup.md` with a step-by-step checklist for macOS setup.
- Document the required prerequisites:
  - Music.app must be installed and openable
  - Music.app should be launched at least once
  - The current macOS user must have access to the Music library
  - Automation permission must be granted for the app used to run SC2AM
- Expand `README.md` with a concise macOS prerequisites section and a link to the setup guide.
- Reference the new setup guide from `docs/architecture.md` for easier discovery.

Closes #15 