### PR TITLE
feat(batch): adds continue-on-error mode (config + CLI)

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,6 +171,9 @@ def download(
     failed = 0
     total = len(urls)
 
+    # Determine effective continue-on-error: CLI flag OR config default
+    effective_continue = continue_on_error or getattr(cfg, 'continue_on_error', False)
+
     # Preserve the existing single-link behavior and messaging.
     if total == 1:
         url = urls[0]
@@ -252,7 +255,7 @@ def download(
             if not is_valid:
                 failed += 1
                 _track_status(logger, track_label, f"ERROR: {platform}", fg='red', level='error')
-                if not continue_on_error:
+                if not effective_continue:
                     abort_with_error = True
                     break
                 continue
@@ -264,7 +267,7 @@ def download(
             if not success:
                 failed += 1
                 _track_status(logger, track_label, f"ERROR: {message}", fg='red', level='error')
-                if not continue_on_error:
+                if not effective_continue:
                     abort_with_error = True
                     break
                 continue
@@ -319,6 +322,8 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
     cfg = state['config']
     logger = state['logger']
 
+    effective_continue = continue_on_error or getattr(cfg, 'continue_on_error', False)
+
     logger.info(f"Processing batch file: {batch_file}")
 
     # Validate batch file
@@ -355,7 +360,7 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
             if not success:
                 _track_status(logger, track_label, f"ERROR: {message}", fg='red', level='error')
                 failed += 1
-                if not continue_on_error:
+                if not effective_continue:
                     abort_with_error = True
                     break
                 continue

--- a/sc2am/config_manager.py
+++ b/sc2am/config_manager.py
@@ -49,7 +49,12 @@ class AppConfig(BaseModel):
         default=True,
         description="Automatically open Apple Music after import"
     )
-    
+    # Batch behavior
+    continue_on_error: bool = Field(
+        default=False,
+        description="When True, continue processing remaining URLs if one fails"
+    )
+
     # Logging
     log_level: str = Field(
         default="INFO",
@@ -143,26 +148,27 @@ class ConfigManager:
         """Extract configuration from environment variables (SC2AM_*)."""
         env_config = {}
         env_prefix = "SC2AM_"
-        
+
         mapping = {
             f"{env_prefix}DOWNLOAD_DIR": "download_dir",
             f"{env_prefix}MUSIC_LIBRARY": "music_library_path",
             f"{env_prefix}PLAYLIST": "default_playlist",
             f"{env_prefix}KEEP_DOWNLOADS": "keep_downloads",
             f"{env_prefix}OPEN_MUSIC": "open_music_app",
+            f"{env_prefix}CONTINUE_ON_ERROR": "continue_on_error",
             f"{env_prefix}LOG_LEVEL": "log_level",
             f"{env_prefix}LOG_FILE": "log_file",
         }
-        
+
         for env_var, config_key in mapping.items():
             value = os.getenv(env_var)
             if value is not None:
                 # Handle boolean values
-                if config_key in ["keep_downloads", "open_music_app"]:
+                if config_key in ["keep_downloads", "open_music_app", "continue_on_error"]:
                     env_config[config_key] = value.lower() in ['true', '1', 'yes']
                 else:
                     env_config[config_key] = value
-        
+
         return env_config
     
     @staticmethod

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -50,6 +50,7 @@ class ConfigDefaultTests(unittest.TestCase):
                 "download_dir": str(home / "Downloads" / "sc2am"),
                 "music_library_path": None,
                 "default_playlist": None,
+                "continue_on_error": False,
                 "keep_downloads": True,
                 "open_music_app": True,
                 "log_level": "INFO",

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -219,6 +219,71 @@ class ErrorMessageTests(unittest.TestCase):
         self.assertEqual(downloader.download.call_count, 2)
         secho_mock.assert_any_call("Summary: 2 succeeded, 0 failed", fg="green", bold=True)
 
+    def test_download_respects_config_continue_on_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+            file_two = download_dir / "two.mp3"
+            file_two.touch()
+
+            cfg = Mock(download_dir=download_dir, open_music_app=False, default_playlist=None, continue_on_error=True)
+            logger = Mock()
+            ctx = mock.Mock()
+            ctx.obj = {"config": cfg, "logger": logger}
+
+            downloader = Mock()
+            downloader.download.side_effect = [
+                (False, None, "Temporary network error"),
+                (True, file_two, "Downloaded: two.mp3"),
+            ]
+
+            urls = (
+                "https://soundcloud.com/artist/one",
+                "https://soundcloud.com/artist/two",
+            )
+
+            download_cmd = cast(Any, main.download)
+            with mock.patch.object(main.URLValidator, "validate_url", return_value=(True, "SoundCloud")), \
+                mock.patch.object(main, "_create_downloader", return_value=downloader), \
+                mock.patch.object(main.click, "secho") as secho_mock:
+                # CLI flag is False, but config.continue_on_error is True -> should continue
+                download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
+
+        self.assertEqual(downloader.download.call_count, 2)
+        secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed", fg="yellow", bold=True)
+
+    def test_batch_respects_config_continue_on_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch_file = Path(tmpdir) / "urls.txt"
+            batch_file.write_text("https://soundcloud.com/artist/one\nhttps://soundcloud.com/artist/two\n")
+
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+            file_two = download_dir / "two.mp3"
+            file_two.touch()
+
+            cfg = Mock(download_dir=download_dir, open_music_app=False, default_playlist=None, continue_on_error=True)
+            logger = Mock()
+            ctx = mock.Mock()
+            ctx.obj = {"config": cfg, "logger": logger}
+
+            downloader = Mock()
+            downloader.download.side_effect = [
+                (False, None, "Temporary error"),
+                (True, file_two, "Downloaded: two.mp3"),
+            ]
+
+            batch_cmd = cast(Any, main.batch)
+            with mock.patch.object(main.URLValidator, "validate_batch_file", return_value=(True, ["https://soundcloud.com/artist/one", "https://soundcloud.com/artist/two"], [])), \
+                mock.patch.object(main, "_create_downloader", return_value=downloader), \
+                mock.patch.object(main, "AppleMusicManager"), \
+                mock.patch.object(main.click, "secho") as secho_mock:
+                # CLI flag False, config True
+                batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, False)
+
+        self.assertEqual(downloader.download.call_count, 2)
+        secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed", fg="yellow", bold=True)
+
     def test_batch_shows_final_summary_with_success_and_failure_counts(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             batch_file = Path(tmpdir) / "urls.txt"


### PR DESCRIPTION
# Summary

Allow batch and multi-link download runs to continue processing remaining URLs when one fails. The behavior can be controlled via the CLI flag `--continue-on-error` or via configuration (`continue_on_error` / `SC2AM_CONTINUE_ON_ERROR`).

## Changes
- Add `continue_on_error` to `AppConfig` (default: false).
- Read `SC2AM_CONTINUE_ON_ERROR` environment variable to override config.
- Honor effective continue-on-error in `batch` and multi-link `download` flows:
  - CLI flag (`--continue-on-error`) takes precedence (OR with config).
- Add unit tests for config-based and CLI-based behavior.
- No breaking API changes; single-link behavior unchanged.

## Validation
- Ran `PYTHONPATH=. pytest -q` (all tests passed).
- New tests:
  - `test_download_respects_config_continue_on_error`
  - `test_batch_respects_config_continue_on_error`

Closes #17 