### PR TITLE
feat: adds retry handling for temporary failures #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ SC2AM_DOWNLOAD_DIR=~/Music python main.py download "..."
 4. **Open** - Launches Apple Music with the tagged MP3 file
 5. **Add** - (Optional) Adds track to specified playlist via AppleScript
 
+SC2AM automatically retries transient download and Apple Music import failures a few times before surfacing an error, so brief network hiccups or a busy Music.app are less likely to interrupt a run.
+
 ## Troubleshooting
 
 ### yt-dlp not found

--- a/sc2am/apple_music.py
+++ b/sc2am/apple_music.py
@@ -6,6 +6,7 @@ Handles opening MP3s with Apple Music and playlist management.
 import logging
 import subprocess
 import platform
+import time
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -14,7 +15,25 @@ logger = logging.getLogger(__name__)
 
 class AppleMusicManager:
     """Manages interaction with Apple Music on macOS."""
-    
+
+    _MAX_RETRIES = 3
+    _RETRY_DELAY_SECONDS = 1.0
+    _RETRYABLE_PATTERNS = (
+        "appleevent timed out",
+        "application isn't responding",
+        "application is not responding",
+        "busy",
+        "connection refused",
+        "connection reset",
+        "gateway timeout",
+        "service unavailable",
+        "temporarily unavailable",
+        "temporary failure",
+        "timed out",
+        "timeout",
+        "try again",
+    )
+
     def __init__(self):
         """Initialize Apple Music manager."""
         self._check_platform()
@@ -24,7 +43,48 @@ class AppleMusicManager:
         """Verify running on macOS."""
         if platform.system() != "Darwin":
             logger.warning("Apple Music manager requires macOS. Current system: " + platform.system())
-    
+
+    @classmethod
+    def _is_retryable_error(cls, stderr: str) -> bool:
+        lowered = (stderr or "").lower()
+        return any(pattern in lowered for pattern in cls._RETRYABLE_PATTERNS)
+
+    @classmethod
+    def _sleep_before_retry(cls, attempt: int) -> None:
+        time.sleep(cls._RETRY_DELAY_SECONDS * attempt)
+
+    @classmethod
+    def _run_command_with_retry(
+        cls,
+        cmd: list[str],
+        operation: str,
+    ) -> Tuple[bool, Optional[subprocess.CompletedProcess], str]:
+        for attempt in range(1, cls._MAX_RETRIES + 1):
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True
+            )
+
+            if result.returncode == 0:
+                return True, result, ""
+
+            error = (result.stderr or result.stdout or "Unknown error").strip()
+            if attempt < cls._MAX_RETRIES and cls._is_retryable_error(error):
+                logger.warning(
+                    f"{operation} failed temporarily on attempt {attempt}/{cls._MAX_RETRIES}: {error}"
+                )
+                cls._sleep_before_retry(attempt)
+                continue
+
+            return False, result, error
+
+        return False, None, "Unknown error"
+
+    @classmethod
+    def _run_osascript(cls, applescript: str, operation: str) -> Tuple[bool, Optional[subprocess.CompletedProcess], str]:
+        return cls._run_command_with_retry(['osascript', '-e', applescript], operation)
+
     @staticmethod
     def open_file_with_music(file_path: Path) -> Tuple[bool, str]:
         """
@@ -45,10 +105,12 @@ class AppleMusicManager:
         try:
             # Use 'open' command with -a flag to open with specific app
             cmd = ['open', '-a', 'Music', str(file_path)]
-            result = subprocess.run(cmd, capture_output=True, text=True)
-            
-            if result.returncode != 0:
-                error = (result.stderr or result.stdout or "Unknown error").strip()
+            success, result, error = AppleMusicManager._run_command_with_retry(
+                cmd,
+                "Opening file with Music",
+            )
+
+            if not success:
                 logger.error(f"Failed to open file with Music app: {error}")
                 # Provide an actionable message that surfaces the underlying error
                 return (
@@ -98,14 +160,12 @@ class AppleMusicManager:
         '''
         
         try:
-            result = subprocess.run(
-                ['osascript', '-e', applescript],
-                capture_output=True,
-                text=True
+            success, result, error = AppleMusicManager._run_osascript(
+                applescript,
+                "Adding track to playlist",
             )
-            
-            if result.returncode != 0:
-                error = (result.stderr or result.stdout or "Unknown error").strip()
+
+            if not success:
                 logger.warning(f"Failed to add to playlist: {error}")
                 return (
                     False,
@@ -139,14 +199,12 @@ class AppleMusicManager:
         '''
         
         try:
-            result = subprocess.run(
-                ['osascript', '-e', applescript],
-                capture_output=True,
-                text=True
+            success, result, error = AppleMusicManager._run_osascript(
+                applescript,
+                "Fetching playlists",
             )
-            
-            if result.returncode != 0:
-                error = (result.stderr or result.stdout or "Unknown error").strip()
+
+            if not success:
                 logger.error(f"Failed to get playlists: {error}")
                 return (
                     False,

--- a/sc2am/downloader.py
+++ b/sc2am/downloader.py
@@ -6,6 +6,7 @@ Handles downloading audio from various platforms using yt-dlp.
 import logging
 import json
 import subprocess
+import time
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple
 import shutil
@@ -17,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 class Downloader:
     """Downloads audio tracks from supported platforms."""
+
+    _MAX_RETRIES = 3
+    _RETRY_DELAY_SECONDS = 1.0
 
     _INVALID_URL_PATTERNS = (
         "unsupported url",
@@ -74,6 +78,15 @@ class Downloader:
             )
         logger.debug(f"yt-dlp found at: {yt_dlp_path}")
 
+    @classmethod
+    def _is_retryable_error(cls, stderr: str) -> bool:
+        lowered = (stderr or "").lower()
+        return any(pattern in lowered for pattern in cls._TEMPORARY_NETWORK_PATTERNS)
+
+    @classmethod
+    def _sleep_before_retry(cls, attempt: int) -> None:
+        time.sleep(cls._RETRY_DELAY_SECONDS * attempt)
+
     def download(self, url: str) -> Tuple[bool, Optional[Path], str]:
         """
         Download audio from URL.
@@ -109,44 +122,65 @@ class Downloader:
             url
         ]
         
-        try:
-            logger.debug(f"Running command: {' '.join(cmd)}")
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=300  # 5 minutes timeout
-            )
-            
-            if result.returncode != 0:
-                error_msg = self._classify_download_error(result.stderr)
-                logger.error(f"Download failed: {error_msg}")
-                return False, None, error_msg
+        for attempt in range(1, self._MAX_RETRIES + 1):
+            try:
+                logger.debug(f"Running command: {' '.join(cmd)}")
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=300  # 5 minutes timeout
+                )
 
-            downloaded_file = self._resolve_downloaded_file(result.stdout)
-            if downloaded_file is None:
-                return False, None, "The download finished, but no MP3 file was created."
+                if result.returncode != 0:
+                    error_msg = self._classify_download_error(result.stderr)
+                    if attempt < self._MAX_RETRIES and self._is_retryable_error(result.stderr):
+                        logger.warning(
+                            f"Temporary download failure on attempt {attempt}/{self._MAX_RETRIES}: {error_msg}"
+                        )
+                        self._sleep_before_retry(attempt)
+                        continue
 
-            metadata_message = ""
-            if track_info:
-                meta_ok, meta_msg = self.metadata_writer.write_to_file(downloaded_file, track_info)
-                if meta_ok:
-                    metadata_message = " (metadata embedded)"
-                else:
-                    metadata_message = " (metadata could not be added)"
-                    logger.warning(f"Metadata tagging issue: {meta_msg}")
+                    logger.error(f"Download failed: {error_msg}")
+                    return False, None, error_msg
 
-            logger.info(f"Successfully downloaded: {downloaded_file.name}")
-            return True, downloaded_file, f"Downloaded: {downloaded_file.name}{metadata_message}"
-        
-        except subprocess.TimeoutExpired:
-            message = "The download timed out. Please try again later."
-            logger.error(message)
-            return False, None, message
-        except Exception as e:
-            message = "The download failed unexpectedly. Please check the log file for details."
-            logger.exception("Unexpected download error")
-            return False, None, message
+                downloaded_file = self._resolve_downloaded_file(result.stdout)
+                if downloaded_file is None:
+                    if attempt < self._MAX_RETRIES:
+                        logger.warning(
+                            f"The download finished without an MP3 file on attempt {attempt}/{self._MAX_RETRIES}; retrying."
+                        )
+                        self._sleep_before_retry(attempt)
+                        continue
+                    return False, None, "The download finished, but no MP3 file was created."
+
+                metadata_message = ""
+                if track_info:
+                    meta_ok, meta_msg = self.metadata_writer.write_to_file(downloaded_file, track_info)
+                    if meta_ok:
+                        metadata_message = " (metadata embedded)"
+                    else:
+                        metadata_message = " (metadata could not be added)"
+                        logger.warning(f"Metadata tagging issue: {meta_msg}")
+
+                logger.info(f"Successfully downloaded: {downloaded_file.name}")
+                return True, downloaded_file, f"Downloaded: {downloaded_file.name}{metadata_message}"
+
+            except subprocess.TimeoutExpired:
+                if attempt < self._MAX_RETRIES:
+                    logger.warning(
+                        f"The download timed out on attempt {attempt}/{self._MAX_RETRIES}; retrying."
+                    )
+                    self._sleep_before_retry(attempt)
+                    continue
+
+                message = "The download timed out. Please try again later."
+                logger.error(message)
+                return False, None, message
+            except Exception:
+                message = "The download failed unexpectedly. Please check the log file for details."
+                logger.exception("Unexpected download error")
+                return False, None, message
 
     @classmethod
     def _classify_download_error(cls, stderr: str) -> str:
@@ -202,24 +236,37 @@ class Downloader:
             url
         ]
         
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30
-            )
-            
-            if result.returncode != 0:
-                error_msg = Downloader._classify_download_error(result.stderr)
-                return False, None, f"Could not fetch track info: {error_msg}"
+        for attempt in range(1, Downloader._MAX_RETRIES + 1):
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30
+                )
 
-            info = json.loads(result.stdout)
-            return True, info, "Info fetched successfully"
-        
-        except json.JSONDecodeError:
-            return False, None, "Could not read track information from yt-dlp."
-        except Exception as e:
-            logger.exception("Error fetching track info")
-            return False, None, "Could not fetch track information. Please check the log file for details."
+                if result.returncode != 0:
+                    error_msg = Downloader._classify_download_error(result.stderr)
+                    if attempt < Downloader._MAX_RETRIES and Downloader._is_retryable_error(result.stderr):
+                        logger.warning(
+                            f"Temporary track-info failure on attempt {attempt}/{Downloader._MAX_RETRIES}: {error_msg}"
+                        )
+                        Downloader._sleep_before_retry(attempt)
+                        continue
+                    return False, None, f"Could not fetch track info: {error_msg}"
+
+                info = json.loads(result.stdout)
+                return True, info, "Info fetched successfully"
+
+            except json.JSONDecodeError:
+                if attempt < Downloader._MAX_RETRIES:
+                    logger.warning(
+                        f"Could not parse track information on attempt {attempt}/{Downloader._MAX_RETRIES}; retrying."
+                    )
+                    Downloader._sleep_before_retry(attempt)
+                    continue
+                return False, None, "Could not read track information from yt-dlp."
+            except Exception:
+                logger.exception("Error fetching track info")
+                return False, None, "Could not fetch track information. Please check the log file for details."
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -10,6 +10,7 @@ import click
 import main
 from main import _exit_with_error, _track_label, _track_status
 import sc2am.apple_music as apple_music
+import sc2am.downloader as downloader_module
 from sc2am.apple_music import AppleMusicManager
 from sc2am.downloader import Downloader
 from sc2am.validator import URLValidator
@@ -42,11 +43,76 @@ class ErrorMessageTests(unittest.TestCase):
             "The track could not be found. It may have been removed or the link may be wrong.",
         )
 
+    def test_downloader_retries_temporary_failure_before_succeeding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+            file_path = download_dir / "track.mp3"
+            file_path.touch()
+
+            with mock.patch.object(Downloader, "_check_dependencies"):
+                downloader = Downloader(download_dir)
+
+            first_attempt = Mock(returncode=1, stdout="", stderr="HTTP Error 503: Service Unavailable")
+            second_attempt = Mock(returncode=0, stdout=f"{file_path}\n", stderr="")
+
+            with mock.patch.object(downloader, "get_track_info", return_value=(True, None, "Info fetched successfully")), \
+                mock.patch.object(downloader_module.subprocess, "run", side_effect=[first_attempt, second_attempt]) as run_mock, \
+                mock.patch.object(downloader_module.time, "sleep") as sleep_mock:
+                success, result_path, message = downloader.download("https://soundcloud.com/artist/track")
+
+        self.assertTrue(success)
+        self.assertEqual(result_path, file_path)
+        self.assertEqual(message, f"Downloaded: {file_path.name}")
+        self.assertEqual(run_mock.call_count, 2)
+        sleep_mock.assert_called_once()
+
+    def test_downloader_does_not_retry_permanent_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+
+            with mock.patch.object(Downloader, "_check_dependencies"):
+                downloader = Downloader(download_dir)
+
+            failure = Mock(returncode=1, stdout="", stderr="HTTP Error 404: Not Found")
+
+            with mock.patch.object(downloader, "get_track_info", return_value=(True, None, "Info fetched successfully")), \
+                mock.patch.object(downloader_module.subprocess, "run", return_value=failure) as run_mock, \
+                mock.patch.object(downloader_module.time, "sleep") as sleep_mock:
+                success, result_path, message = downloader.download("https://soundcloud.com/artist/track")
+
+        self.assertFalse(success)
+        self.assertIsNone(result_path)
+        self.assertEqual(
+            message,
+            "The track could not be found. It may have been removed or the link may be wrong.",
+        )
+        self.assertEqual(run_mock.call_count, 1)
+        sleep_mock.assert_not_called()
+
     def test_missing_music_file_returns_clear_error(self):
         success, message = AppleMusicManager.open_file_with_music(Path("/tmp/does-not-exist.mp3"))
 
         self.assertFalse(success)
         self.assertEqual(message, "The downloaded file was not found.")
+
+    def test_open_file_with_music_retries_temporary_failure_before_succeeding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "track.mp3"
+            file_path.touch()
+
+            first_attempt = Mock(returncode=1, stdout="", stderr="AppleEvent timed out")
+            second_attempt = Mock(returncode=0, stdout="", stderr="")
+
+            with mock.patch.object(apple_music.subprocess, "run", side_effect=[first_attempt, second_attempt]) as run_mock, \
+                mock.patch.object(apple_music.time, "sleep") as sleep_mock:
+                success, message = AppleMusicManager.open_file_with_music(file_path)
+
+        self.assertTrue(success)
+        self.assertEqual(message, "Opened with Apple Music")
+        self.assertEqual(run_mock.call_count, 2)
+        sleep_mock.assert_called_once()
 
     def test_missing_playlist_file_returns_clear_error(self):
         success, message = AppleMusicManager.add_to_playlist(
@@ -122,6 +188,27 @@ class ErrorMessageTests(unittest.TestCase):
         self.assertEqual(message, "Added to playlist 'Roadtrip'")
         self.assertTrue(run_mock.called)
 
+    def test_add_to_playlist_retries_temporary_failure_before_succeeding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "track.mp3"
+            file_path.touch()
+
+            first_attempt = Mock(returncode=1, stdout="", stderr="AppleEvent timed out")
+            second_attempt = Mock(returncode=0, stdout="", stderr="")
+
+            with mock.patch.object(
+                AppleMusicManager,
+                "get_playlists",
+                return_value=(True, ["Roadtrip"], "Playlists retrieved"),
+            ), mock.patch.object(apple_music.subprocess, "run", side_effect=[first_attempt, second_attempt]) as run_mock, \
+                mock.patch.object(apple_music.time, "sleep") as sleep_mock:
+                success, message = AppleMusicManager.add_to_playlist(file_path, "Roadtrip")
+
+        self.assertTrue(success)
+        self.assertEqual(message, "Added to playlist 'Roadtrip'")
+        self.assertEqual(run_mock.call_count, 2)
+        sleep_mock.assert_called_once()
+
     def test_exit_helper_raises_click_exception(self):
         logger = Mock()
 
@@ -138,7 +225,7 @@ class ErrorMessageTests(unittest.TestCase):
     def test_track_status_logs_with_matching_severity(self):
         logger = Mock()
 
-        with mock.patch.object(main.click, "secho") as secho_mock:
+        with mock.patch.object(click, "secho") as secho_mock:
             _track_status(logger, "Track 1/1", "ERROR: Failed", fg="red", level="error")
 
         secho_mock.assert_called_once_with("Track 1/1: ERROR: Failed", fg="red", bold=False)
@@ -150,7 +237,7 @@ class ErrorMessageTests(unittest.TestCase):
     def test_run_summary_reports_success_and_failure_counts(self):
         logger = Mock()
 
-        with mock.patch.object(main.click, "secho") as secho_mock:
+        with mock.patch.object(click, "secho") as secho_mock:
             main._print_run_summary(logger, 3, 1)
 
         secho_mock.assert_called_once_with("Summary: 3 succeeded, 1 failed", fg="yellow", bold=True)
@@ -174,7 +261,7 @@ class ErrorMessageTests(unittest.TestCase):
             download_cmd = cast(Any, main.download)
             with mock.patch.object(main.URLValidator, "validate_url", return_value=(True, "SoundCloud")), \
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
-                mock.patch.object(main.click, "secho") as secho_mock:
+                mock.patch.object(click, "secho") as secho_mock:
                 download_cmd.callback.__wrapped__(
                     ctx,
                     ("https://soundcloud.com/artist/track",),
@@ -213,7 +300,7 @@ class ErrorMessageTests(unittest.TestCase):
             download_cmd = cast(Any, main.download)
             with mock.patch.object(main.URLValidator, "validate_url", return_value=(True, "SoundCloud")), \
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
-                mock.patch.object(main.click, "secho") as secho_mock:
+                mock.patch.object(click, "secho") as secho_mock:
                 download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
 
         self.assertEqual(downloader.download.call_count, 2)
@@ -245,7 +332,7 @@ class ErrorMessageTests(unittest.TestCase):
             download_cmd = cast(Any, main.download)
             with mock.patch.object(main.URLValidator, "validate_url", return_value=(True, "SoundCloud")), \
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
-                mock.patch.object(main.click, "secho") as secho_mock:
+                mock.patch.object(click, "secho") as secho_mock:
                 # CLI flag is False, but config.continue_on_error is True -> should continue
                 download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
 
@@ -276,8 +363,8 @@ class ErrorMessageTests(unittest.TestCase):
             batch_cmd = cast(Any, main.batch)
             with mock.patch.object(main.URLValidator, "validate_batch_file", return_value=(True, ["https://soundcloud.com/artist/one", "https://soundcloud.com/artist/two"], [])), \
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
-                mock.patch.object(main, "AppleMusicManager"), \
-                mock.patch.object(main.click, "secho") as secho_mock:
+                mock.patch.object(apple_music, "AppleMusicManager"), \
+                mock.patch.object(click, "secho") as secho_mock:
                 # CLI flag False, config True
                 batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, False)
 
@@ -308,8 +395,8 @@ class ErrorMessageTests(unittest.TestCase):
             batch_cmd = cast(Any, main.batch)
             with mock.patch.object(main.URLValidator, "validate_batch_file", return_value=(True, ["https://soundcloud.com/artist/one", "https://soundcloud.com/artist/two"], [])), \
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
-                mock.patch.object(main, "AppleMusicManager"), \
-                mock.patch.object(main.click, "secho") as secho_mock:
+                mock.patch.object(apple_music, "AppleMusicManager"), \
+                mock.patch.object(click, "secho") as secho_mock:
                 batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, True)
 
         secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed", fg="yellow", bold=True)


### PR DESCRIPTION
# Summary

Add automatic retries for transient download and Apple Music import failures to reduce manual intervention during short-lived network hiccups or temporarily busy Music.app/AppleScript operations.

## Changes
- Retry transient `yt-dlp` download failures and track-info fetches in `sc2am/downloader.py`
- Retry transient Apple Music open/import/playlist operations in `sc2am/apple_music.py`
- Keep permanent failures fast-failing without unnecessary retries
- Add tests covering retry success and permanent-failure behavior
- Update `README.md` with a short note about automatic retries

## Validation
- Ran `PYTHONPATH=. pytest -q`
- All tests passed locally

Closes #18 