### PR TITLE
fix: upgrades dependencies to patch security CVEs for v1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sc2am"
-version = "1.4.0"
+version = "1.4.1"
 description = "Automate downloading SoundCloud tracks and importing them to Apple Music"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -29,12 +29,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "yt-dlp>=2024.0.0",
+    "yt-dlp>=2026.7.4",
     "click>=8.1.0",
     "pyyaml>=6.0",
-    "requests>=2.31.0",
+    "requests>=2.33.0",
     "mutagen>=1.46.0",
-    "pydantic>=2.0.0",
+    "pydantic>=2.4.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-yt-dlp>=2024.0.0
+yt-dlp>=2026.7.4
 click>=8.1.0
 pyyaml>=6.0
-requests>=2.31.0
+requests>=2.33.0
 mutagen>=1.46.0
-pydantic>=2.0.0
+pydantic>=2.4.0

--- a/sc2am/__init__.py
+++ b/sc2am/__init__.py
@@ -2,7 +2,7 @@
 SC2AM - SoundCloud to Apple Music automation tool
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "zFl4wless"
 __description__ = "Automate downloading SoundCloud tracks and importing them to Apple Music"
 


### PR DESCRIPTION
# Summary

Upgrade vulnerable dependencies to remove known CVEs before the v1.4.1 patch release.

## Changes
- Upgraded `yt-dlp` from `2024.0.0` to `2026.7.4`
- Upgraded `requests` from `2.31.0` to `2.33.0`
- Upgraded `pydantic` from `2.0.0` to `2.4.0`
- Bumped project version from `1.4.0` to `1.4.1`

## Validation
- [x] Ran `PYTHONPATH=. pytest -q` — 47 tests passed
- [x] Ran CVE validation — no known CVEs remaining for the updated dependencies