### PR TITLE
refactor: polishes logging output and standardizes CLI exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,16 @@ SC2AM_DOWNLOAD_DIR=~/Music python main.py download "..."
 
 SC2AM automatically retries transient download and Apple Music import failures a few times before surfacing an error, so brief network hiccups or a busy Music.app are less likely to interrupt a run.
 
+### Exit Codes and Logging Behavior
+
+SC2AM now returns stable exit codes for scripting:
+
+- `0` - all requested work succeeded
+- `1` - at least one item failed during processing
+- `2` - usage/input error (for example invalid CLI input or invalid configuration)
+
+CLI progress output is written as clean status lines. Python logger output on the console is limited to warnings and errors so informational log lines do not duplicate the CLI status messages. To retain detailed logs, configure `log_file`.
+
 ### Batch Processing Output
 
 When running batch operations with multiple links or URLs from a file, SC2AM provides improved logging and summary output to help you debug and understand the results:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ SC2AM is a small command-line application that downloads a SoundCloud track, enr
 - Metadata should be normalized before tagging so downstream code receives predictable values.
 - Artwork handling should always prefer a valid embedded image and fall back safely when no usable artwork exists.
 - CLI errors should be clear enough for users to act on without reading stack traces.
+- CLI exit codes should stay stable (`0` success, `1` processing failure, `2` usage/config input error) so automation can rely on them.
 - The project should remain macOS-friendly but avoid hard-coding local paths or machine-specific assumptions.
 
 ## macOS Setup Notes
@@ -44,4 +45,3 @@ The most important tests cover:
 
 ## Release Notes
 When preparing a release, verify that the code version and package version match, then summarize user-visible improvements in release notes.
-

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ Command-line interface and main entry point
 
 import logging
 import sys
+from enum import IntEnum
 from pathlib import Path
 from typing import Any, Dict, Optional, NoReturn, Tuple, cast
 
@@ -17,9 +18,22 @@ from sc2am.downloader import Downloader
 from sc2am.apple_music import AppleMusicManager
 
 
-def _exit_with_error(logger, message: str, detail: Optional[str] = None) -> NoReturn:
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    ERROR = 1
+    USAGE = 2
+
+
+def _exit_with_error(
+    logger,
+    message: str,
+    detail: Optional[str] = None,
+    exit_code: int = int(ExitCode.ERROR),
+) -> NoReturn:
     logger.error(detail or message)
-    raise click.ClickException(message)
+    exc = click.ClickException(message)
+    exc.exit_code = exit_code
+    raise exc
 
 
 def _create_downloader(cfg, logger) -> Downloader:
@@ -129,9 +143,11 @@ def cli(ctx: click.Context, config: Optional[str], log_level: str):
     try:
         cfg = ConfigManager.get_config(config_path)
     except Exception as exc:
-        raise click.ClickException(
+        click_exc = click.ClickException(
             "Failed to load configuration. Please check your config file and environment variables."
-        ) from exc
+        )
+        click_exc.exit_code = int(ExitCode.USAGE)
+        raise click_exc from exc
 
     # Override log level if specified
     if log_level:
@@ -206,7 +222,7 @@ def download(
             is_valid, platform = URLValidator.validate_url(url)
             if not is_valid:
                 failed = 1
-                _exit_with_error(logger, platform)
+                _exit_with_error(logger, platform, exit_code=int(ExitCode.USAGE))
 
             _track_status(logger, track_label, f"OK: Valid {platform} URL", fg='green')
             logger.debug(f"URL validated as {platform}")
@@ -267,7 +283,6 @@ def download(
     downloader = _create_downloader(cfg, logger)
     music_manager = AppleMusicManager()
     playlist_name = _resolve_playlist_name(cfg, playlist)
-    abort_with_error = False
     failed_items = []
 
     try:
@@ -285,7 +300,6 @@ def download(
                 failed_items.append((url, error_msg))
                 _track_status(logger, track_label, f"ERROR: {platform}", fg='red', level='error')
                 if not effective_continue:
-                    abort_with_error = True
                     break
                 continue
 
@@ -309,7 +323,6 @@ def download(
                 failed_items.append((url, message))
                 _track_status(logger, track_label, f"ERROR: {message}", fg='red', level='error')
                 if not effective_continue:
-                    abort_with_error = True
                     break
                 continue
 
@@ -337,8 +350,8 @@ def download(
     finally:
         _print_run_summary(logger, succeeded, failed, failed_items)
 
-    if abort_with_error:
-        sys.exit(1)
+    if failed > 0:
+        sys.exit(int(ExitCode.ERROR))
 
 
 @cli.command()
@@ -382,7 +395,11 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
             logger.error(f"Line {line_num}: {error}")
 
     if not urls:
-        _exit_with_error(logger, "No valid URLs found in batch file.")
+        _exit_with_error(
+            logger,
+            "No valid URLs found in batch file.",
+            exit_code=int(ExitCode.USAGE),
+        )
 
     click.secho(f"OK: Found {len(urls)} valid URL(s)", fg='green')
     logger.info(f"Found {len(urls)} valid URLs")
@@ -392,9 +409,8 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
 
     music_manager = AppleMusicManager()
     successful = 0
-    failed = 0
-    abort_with_error = False
-    failed_items = []
+    failed = len(errors)
+    failed_items = [(f"line {line_num}", error) for line_num, error in errors]
 
     try:
         for i, url in enumerate(urls, 1):
@@ -423,7 +439,6 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
                 _track_status(logger, track_label, f"ERROR: {message}", fg='red', level='error')
                 failed += 1
                 if not effective_continue:
-                    abort_with_error = True
                     break
                 continue
 
@@ -456,8 +471,8 @@ def batch(ctx: click.Context, batch_file: str, playlist: Optional[str], continue
     finally:
         _print_run_summary(logger, successful, failed, failed_items)
 
-    if abort_with_error:
-        sys.exit(1)
+    if failed > 0:
+        sys.exit(int(ExitCode.ERROR))
 
 
 @cli.group()

--- a/sc2am/logger.py
+++ b/sc2am/logger.py
@@ -20,31 +20,29 @@ def setup_logging(log_level: str = "INFO", log_file: Optional[Path] = None) -> l
         Logger instance
     """
     logger = logging.getLogger("sc2am")
-    logger.setLevel(log_level.upper())
-    
+    requested_level = getattr(logging, log_level.upper(), logging.INFO)
+    logger.setLevel(requested_level)
+    logger.propagate = False
+
     # Remove existing handlers
     logger.handlers.clear()
-    
-    # Console handler
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(log_level.upper())
-    console_formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
+
+    # Console handler: keep CLI output clean by only surfacing warnings/errors.
+    console_handler = logging.StreamHandler(sys.stderr)
+    console_handler.setLevel(max(requested_level, logging.WARNING))
+    console_formatter = logging.Formatter('%(levelname)s: %(message)s')
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
-    
+
     # File handler (if specified)
     if log_file:
         log_file.parent.mkdir(parents=True, exist_ok=True)
         file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(log_level.upper())
+        file_handler.setLevel(requested_level)
         file_formatter = logging.Formatter(
             '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         )
         file_handler.setFormatter(file_formatter)
         logger.addHandler(file_handler)
-    
-    return logger
 
+    return logger

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -8,7 +8,7 @@ from unittest import mock
 import click
 
 import main
-from main import _exit_with_error, _track_label, _track_status
+from main import ExitCode, _exit_with_error, _track_label, _track_status
 import sc2am.apple_music as apple_music
 import sc2am.downloader as downloader_module
 from sc2am.apple_music import AppleMusicManager
@@ -216,7 +216,20 @@ class ErrorMessageTests(unittest.TestCase):
             _exit_with_error(logger, "Something went wrong.")
 
         self.assertEqual(str(ctx.exception), "Something went wrong.")
+        self.assertEqual(ctx.exception.exit_code, int(ExitCode.ERROR))
         logger.error.assert_called_once_with("Something went wrong.")
+
+    def test_exit_helper_supports_custom_exit_code(self):
+        logger = Mock()
+
+        with self.assertRaises(click.ClickException) as ctx:
+            _exit_with_error(
+                logger,
+                "Invalid URL input.",
+                exit_code=int(ExitCode.USAGE),
+            )
+
+        self.assertEqual(ctx.exception.exit_code, int(ExitCode.USAGE))
 
     def test_track_label_formats_single_and_batch_tracks(self):
         self.assertEqual(_track_label(), "Track")
@@ -334,9 +347,11 @@ class ErrorMessageTests(unittest.TestCase):
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
                 mock.patch.object(click, "secho") as secho_mock:
                 # CLI flag is False, but config.continue_on_error is True -> should continue
-                download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
+                with self.assertRaises(SystemExit) as exit_ctx:
+                    download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
 
         self.assertEqual(downloader.download.call_count, 2)
+        self.assertEqual(exit_ctx.exception.code, int(ExitCode.ERROR))
         secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed (50% success rate)", fg="yellow", bold=True)
 
     def test_batch_respects_config_continue_on_error(self):
@@ -366,9 +381,11 @@ class ErrorMessageTests(unittest.TestCase):
                 mock.patch.object(apple_music, "AppleMusicManager"), \
                 mock.patch.object(click, "secho") as secho_mock:
                 # CLI flag False, config True
-                batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, False)
+                with self.assertRaises(SystemExit) as exit_ctx:
+                    batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, False)
 
         self.assertEqual(downloader.download.call_count, 2)
+        self.assertEqual(exit_ctx.exception.code, int(ExitCode.ERROR))
         secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed (50% success rate)", fg="yellow", bold=True)
 
     def test_batch_shows_final_summary_with_success_and_failure_counts(self):
@@ -397,8 +414,10 @@ class ErrorMessageTests(unittest.TestCase):
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
                 mock.patch.object(apple_music, "AppleMusicManager"), \
                 mock.patch.object(click, "secho") as secho_mock:
-                batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, True)
+                with self.assertRaises(SystemExit) as exit_ctx:
+                    batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, True)
 
+        self.assertEqual(exit_ctx.exception.code, int(ExitCode.ERROR))
         secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed (50% success rate)", fg="yellow", bold=True)
 
     def test_batch_shows_detailed_error_list_for_failed_tracks(self):
@@ -459,15 +478,54 @@ class ErrorMessageTests(unittest.TestCase):
             with mock.patch.object(main.URLValidator, "validate_url", return_value=(True, "SoundCloud")), \
                 mock.patch.object(main, "_create_downloader", return_value=downloader), \
                 mock.patch.object(click, "secho") as secho_mock:
-                download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
+                with self.assertRaises(SystemExit) as exit_ctx:
+                    download_cmd.callback.__wrapped__(ctx, urls, None, True, False)
 
         # Verify summary shows correct counts
+        self.assertEqual(exit_ctx.exception.code, int(ExitCode.ERROR))
         secho_mock.assert_any_call("Summary: 1 succeeded, 2 failed (33% success rate)", fg="yellow", bold=True)
         # Verify error header is shown
         secho_mock.assert_any_call("\nFailed tracks:", fg="red", bold=True)
         # Verify failed URLs are listed
         secho_mock.assert_any_call("  1. https://soundcloud.com/artist/two", fg="red")
         secho_mock.assert_any_call("  2. https://soundcloud.com/artist/three", fg="red")
+
+    def test_batch_counts_input_line_errors_as_failures(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch_file = Path(tmpdir) / "urls.txt"
+            batch_file.write_text("bad-url\nhttps://soundcloud.com/artist/ok\n")
+
+            download_dir = Path(tmpdir) / "downloads"
+            download_dir.mkdir()
+            file_one = download_dir / "ok.mp3"
+            file_one.touch()
+
+            cfg = Mock(download_dir=download_dir, open_music_app=False, default_playlist=None, continue_on_error=True)
+            logger = Mock()
+            ctx = mock.Mock()
+            ctx.obj = {"config": cfg, "logger": logger}
+
+            downloader = Mock()
+            downloader.download.return_value = (True, file_one, "Downloaded: ok.mp3")
+
+            batch_cmd = cast(Any, main.batch)
+            with mock.patch.object(
+                main.URLValidator,
+                "validate_batch_file",
+                return_value=(
+                    False,
+                    ["https://soundcloud.com/artist/ok"],
+                    [(1, "Please provide a valid URL.")],
+                ),
+            ), mock.patch.object(main, "_create_downloader", return_value=downloader), \
+                mock.patch.object(apple_music, "AppleMusicManager"), \
+                mock.patch.object(click, "secho") as secho_mock:
+                with self.assertRaises(SystemExit) as exit_ctx:
+                    batch_cmd.callback.__wrapped__(ctx, str(batch_file), None, False)
+
+        self.assertEqual(exit_ctx.exception.code, int(ExitCode.ERROR))
+        secho_mock.assert_any_call("Summary: 1 succeeded, 1 failed (50% success rate)", fg="yellow", bold=True)
+        secho_mock.assert_any_call("  1. line 1", fg="red")
 
 
 if __name__ == "__main__":

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from sc2am.logger import setup_logging
+
+
+class LoggerSetupTests(unittest.TestCase):
+    def test_console_handler_uses_stderr_and_warning_floor(self):
+        logger = setup_logging("INFO", None)
+
+        self.assertFalse(logger.propagate)
+        self.assertEqual(len(logger.handlers), 1)
+
+        console_handler = logger.handlers[0]
+        self.assertIs(console_handler.stream, sys.stderr)
+        self.assertEqual(console_handler.level, logging.WARNING)
+
+    def test_console_handler_respects_higher_requested_level(self):
+        logger = setup_logging("ERROR", None)
+
+        self.assertEqual(len(logger.handlers), 1)
+        self.assertEqual(logger.handlers[0].level, logging.ERROR)
+
+    def test_file_handler_uses_requested_level(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "sc2am.log"
+            logger = setup_logging("DEBUG", log_path)
+
+        self.assertEqual(len(logger.handlers), 2)
+        file_handlers = [handler for handler in logger.handlers if isinstance(handler, logging.FileHandler)]
+        self.assertEqual(len(file_handlers), 1)
+        self.assertEqual(file_handlers[0].level, logging.DEBUG)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

- standardize CLI exit codes for success, processing failures, and usage/config input errors
- make console logging cleaner and script-friendly while preserving detailed file logs
- update tests and docs for the new logging/exit-code contract

Closes #25 